### PR TITLE
Add URL validation helper to TheFooter component

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -6,11 +6,11 @@
           class="text-sm text-gray-500 transition hover:text-gray-600"
           target="_blank"
           rel="noopener noreferrer"
-          :href="`mailto:${siteMetadata.email}`"
+          :href="sanitizeHref(`mailto:${siteMetadata.email}`)"
           ><span class="sr-only">email</span>
           <img class="w-8 h-8" src="~assets/icon/mail.svg" /></a
         >
-        <a class="text-sm text-gray-500 transition hover:text-gray-600" target="_blank" rel="noopener noreferrer" :href="i.href" v-for="i in items" :key="i.title">
+        <a class="text-sm text-gray-500 transition hover:text-gray-600" target="_blank" rel="noopener noreferrer" :href="sanitizeHref(i.href)" v-for="i in items" :key="i.title">
             <span class="sr-only">{{i.title}}</span>
             <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'cursor'" src="~assets/icon/cursor.svg"/>
             <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'facebook'" src="~assets/icon/facebook.svg"/>
@@ -25,7 +25,7 @@
         </a>
       </div>
       <div class="flex mb-2 mt-8 space-x-2 text-sm text-gray-500 dark:text-gray-400">
-        <div>Copyright © {{ new Date().getFullYear() }} • <a :href="siteMetadata.siteUrl">{{ siteMetadata.author }}</a
+        <div>Copyright © {{ new Date().getFullYear() }} • <a :href="sanitizeHref(siteMetadata.siteUrl)">{{ siteMetadata.author }}</a
           ></div>       
         </div>
         <div class="mb-8 text-sm text-gray-500 dark:text-gray-400">
@@ -53,6 +53,27 @@
     },
     components: {
       BuyMeACoffee
+    },
+    methods: {
+      sanitizeHref(href) {
+        if (!href) return "#";
+        const allowedProtocols = ["http:", "https:", "mailto:"];
+        try {
+          const url = new URL(href, "http://local-base");
+          if (allowedProtocols.includes(url.protocol)) {
+            return href;
+          }
+          if (href.startsWith("/") || href.startsWith("#")) {
+            return href;
+          }
+          return "#";
+        } catch (e) {
+          if (href.startsWith("/") || href.startsWith("#") || href.startsWith("mailto:")) {
+            return href;
+          }
+          return "#";
+        }
+      }
     },
     async fetch() {
       this.items = await fetch(this.API_URL).then(res => res.json());


### PR DESCRIPTION
Implemented a `sanitizeHref` helper method in `components/TheFooter.vue` to validate and sanitize URLs before binding them to `href` attributes. This security measure ensures that only safe protocols such as `http:`, `https:`, and `mailto:` are allowed, while potentially dangerous protocols like `javascript:`, `data:`, and `file:` are blocked and replaced with a safe fallback (`#`). All dynamic `href` bindings in the footer, including social media links and author information, have been updated to use this sanitization helper. Verified the changes with `npm run build` and a code review.

---
*PR created automatically by Jules for task [7783658224347763693](https://jules.google.com/task/7783658224347763693) started by @georgebrata*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link validation in the footer to ensure proper handling of email and website URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->