### PR TITLE
Fix JS-W1038: Remove excess arguments passed to functions

### DIFF
--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -32,7 +32,7 @@ export default {
       
       let visibleArticles = articles.filter((article) => !article.draft);
       const latestArticle = visibleArticles.sort((a, b) => new Date(b.date) - new Date(a.date))[0];
-      visibleArticles.shift(1); // remove the latest article from the list
+      visibleArticles.shift(); // remove the latest article from the list
 
     const categories = [
       { name: 'VueJS' }, { name: 'Nuxt' }, { name: 'Gridsome' }, { name: 'VuePress' },

--- a/static/js/ga.js
+++ b/static/js/ga.js
@@ -1,5 +1,5 @@
 window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
+function gtag(...args){dataLayer.push(args);}
 gtag('js', new Date());
 
 gtag('config', 'G-40P7NL2EGP');


### PR DESCRIPTION
This PR addresses the DeepSource linter rule JS-W1038 by removing unnecessary arguments from function calls and updating variadic function signatures.

### Changes:
- **`static/js/ga.js`**: Updated the `gtag` function definition to use ES6 rest parameters (`...args`). This explicitly allows the function to accept multiple arguments, which is its intended use case for Google Analytics, thus satisfying the linter.
- **`pages/blog/index.vue`**: Changed `visibleArticles.shift(1)` to `visibleArticles.shift()`. The `shift` method of `Array.prototype` does not take any arguments; the passed `1` was redundant and ignored by the runtime.

### Why:
- **Code Quality**: Ensures function calls match their definitions or the language specification.
- **Linter Compliance**: Resolves 2 occurrences of JS-W1038 reported by DeepSource.
- **Readability**: Removes confusing or misleading arguments from the code.

---
*PR created automatically by Jules for task [2126331464737082085](https://jules.google.com/task/2126331464737082085) started by @georgebrata*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor code cleanup and optimization with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->