### PR TITLE
Add name property to Vue components

### DIFF
--- a/components/AuthorCard.vue
+++ b/components/AuthorCard.vue
@@ -119,6 +119,7 @@ import Glob from "../assets/icon/glob.svg?inline";
 import Github from "../assets/icon/github_new.svg?inline";
 import siteMetaInfo from "@/data/sitemetainfo";
 export default {
+  name: "AuthorCard",
   components: { Mail, Glob, Github },
   data: () => {
     return {

--- a/components/AuthorIntro.vue
+++ b/components/AuthorIntro.vue
@@ -16,6 +16,7 @@
 </template>
 <script>
 export default {
+  name: "AuthorIntro",
   data: () => {
     return {
       items: [],

--- a/components/BuyMeACoffee.vue
+++ b/components/BuyMeACoffee.vue
@@ -8,7 +8,9 @@
 </template>
 
 <script>
-export default {};
+export default {
+  name: "BuyMeACoffee",
+};
 </script>
 
 <style></style>

--- a/components/DownloadCvBtn.vue
+++ b/components/DownloadCvBtn.vue
@@ -8,6 +8,7 @@
 
 <script>
 export default {
+  name: "DownloadCvBtn",
   props: ["file", "name", "fullwidth"],
   methods: {
     downloadFile() {

--- a/components/Expertise.vue
+++ b/components/Expertise.vue
@@ -205,6 +205,7 @@
   import Jira from "../assets/devicon/jira.svg?inline";
 
   export default {
+    name: "Expertise",
     components: {
       Javascript,
       Html,

--- a/components/HireMeBtn.vue
+++ b/components/HireMeBtn.vue
@@ -9,6 +9,7 @@
 import siteMetaInfo from "@/data/sitemetainfo";
 
 export default {
+  name: "HireMeBtn",
   props: ["fullwidth"],
     data: () => {
     return {

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -72,6 +72,7 @@ import Folder from "../assets/icon/folder.svg?inline";
 import External from "../assets/icon/external.svg?inline";
 import Github from "../assets/icon/github.svg?inline";
 export default {
+  name: "ProjectCard",
   props: ["item"],
   components: { Folder, External, Github },
   data() {

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -44,6 +44,7 @@
   import siteMetaInfo from "@/data/sitemetainfo";
   import BuyMeACoffee from "./BuyMeACoffee.vue";
   export default {
+    name: "TheFooter",
     data() {
       return {
         siteMetadata: siteMetaInfo,

--- a/components/TimeLine.vue
+++ b/components/TimeLine.vue
@@ -51,6 +51,7 @@
 
 <script>
 export default {
+  name: "TimeLine",
   data: () => {
     return {
       items: [],

--- a/components/blogItem.vue
+++ b/components/blogItem.vue
@@ -30,6 +30,7 @@
 
 <script>
 export default {
+  name: "BlogItem",
   props: ["item"],
   data() {
     return {

--- a/components/blogItemLarge.vue
+++ b/components/blogItemLarge.vue
@@ -47,6 +47,7 @@
   
 <script>
 export default {
+  name: "BlogItemLarge",
   // props: ["title", "description", "date", "slug", "categories", "author", "image", "readingTime"],
   props: ["item"],
   data() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,7 +14,8 @@ import TheHeader from "../components/TheHeader.vue";
 import TheFooter from "../components/TheFooter.vue";
 
 export default {
-  component: {
+  name: "DefaultLayout",
+  components: {
     TheHeader,
     TheFooter,
   },

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -64,6 +64,7 @@
 import Prism from "~/plugins/prism";
 import siteMetaInfo from "@/data/sitemetainfo";
 export default {
+  name: "BlogSlug",
   data() {
     return {
       title: 0,

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -14,6 +14,7 @@
 
 <script>
 export default {
+  name: "BlogIndex",
   async asyncData({ $content }) {
     const articles = await $content("articles")
       .only([

--- a/pages/hobbies.vue
+++ b/pages/hobbies.vue
@@ -87,6 +87,7 @@
 <script>
     // import projectsData from "../data/projects";
     export default {
+        name: "Hobbies",
         data() {
             return {
                 items: [],

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,6 +16,7 @@
 <script>
 import siteMetaInfo from "@/data/sitemetainfo";
 export default {
+  name: "Index",
   data() {
     return {
       siteMetaInfo: siteMetaInfo,


### PR DESCRIPTION
I have added the `name` property to all Vue components, layouts, and pages that were missing it (16 occurrences in total). This follows Vue's best practices for better debugging and recursion support. Additionally, I corrected a typo in `layouts/default.vue` where `component` was used instead of `components` for component registration. All changes have been verified to build successfully.

---
*PR created automatically by Jules for task [9802836502882784094](https://jules.google.com/task/9802836502882784094) started by @georgebrata*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit component naming across the application to improve debugging and Vue DevTools compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->