### PR TITLE
Fix security risk: Avoid target='_blank' without rel='noopener noreferrer'

### DIFF
--- a/components/AuthorCard.vue
+++ b/components/AuthorCard.vue
@@ -84,6 +84,7 @@
         </div>
         <a
           target="_blank"
+          rel="noopener noreferrer"
           :href="`mailto:${siteMetadata.email}`"
           class="text-gray-600 md:hidden mt-1 dark:text-blue-100"
         >
@@ -99,7 +100,7 @@
       </div>
       <div class="my-2 text-gray-600 flex dark:text-blue-100 mb-4">
         <Mail />
-        <a class="ml-2" target="_blank" :href="`mailto:${siteMetadata.email}`"> {{ siteMetadata.email }}</a>
+        <a class="ml-2" target="_blank" rel="noopener noreferrer" :href="`mailto:${siteMetadata.email}`"> {{ siteMetadata.email }}</a>
       </div>
       <HireMeBtn :fullwidth="true">Contact me</HireMeBtn>
 

--- a/components/BuyMeACoffee.vue
+++ b/components/BuyMeACoffee.vue
@@ -1,5 +1,5 @@
 <template>
-  <a href="https://www.buymeacoffee.com/mdrathik" target="_blank"
+  <a href="https://www.buymeacoffee.com/mdrathik" target="_blank" rel="noopener noreferrer"
     ><img
       src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
       alt="Buy Me A Coffee"

--- a/components/HireMeBtn.vue
+++ b/components/HireMeBtn.vue
@@ -1,5 +1,5 @@
 <template>
-    <a target="_blank" :href="`mailto:${siteMetadata.email}`"><button type="button" class="text-white bg-gradient-to-br from-purple-600 to-blue-900 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-bold rounded-lg text-md px-5 py-2.5 text-center mr-2 mb-2"  :class="{'w-full':fullwidth}">
+    <a target="_blank" rel="noopener noreferrer" :href="`mailto:${siteMetadata.email}`"><button type="button" class="text-white bg-gradient-to-br from-purple-600 to-blue-900 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-bold rounded-lg text-md px-5 py-2.5 text-center mr-2 mb-2"  :class="{'w-full':fullwidth}">
         <slot></slot>
       </button>
     </a>

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -45,6 +45,7 @@
         </div>
         <a
           target="_blank"
+          rel="noopener noreferrer"
           :href="siteMetadata.siteUrl"
           class="text-indigo-500 hover:text-indigo-600 dark:text-indigo-400"
         >


### PR DESCRIPTION
Added `rel="noopener noreferrer"` to all anchor tags using `target="_blank"` to mitigate the risk of tabnabbing (CWE-1022). Affected files include:
- `pages/blog/_slug.vue`
- `components/HireMeBtn.vue`
- `components/AuthorCard.vue`
- `components/BuyMeACoffee.vue`

---
*PR created automatically by Jules for task [9389239393530263060](https://jules.google.com/task/9389239393530263060) started by @georgebrata*