### PR TITLE
Remove unused registered components from SFCs

### DIFF
--- a/components/AuthorCard.vue
+++ b/components/AuthorCard.vue
@@ -117,11 +117,10 @@
 <script>
 import Mail from "../assets/icon/mail.svg?inline";
 import Glob from "../assets/icon/glob.svg?inline";
-import Github from "../assets/icon/github_new.svg?inline";
 import siteMetaInfo from "@/data/sitemetainfo";
 export default {
   name: "AuthorCard",
-  components: { Mail, Glob, Github },
+  components: { Mail, Glob },
   data: () => {
     return {
       clickIndex: 1,

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -68,13 +68,10 @@
 </template>
 
 <script>
-import Folder from "../assets/icon/folder.svg?inline";
-import External from "../assets/icon/external.svg?inline";
-import Github from "../assets/icon/github.svg?inline";
 export default {
   name: "ProjectCard",
   props: ["item"],
-  components: { Folder, External, Github },
+  components: { },
   data() {
     return {
 

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -42,7 +42,6 @@
 
 <script>
   import siteMetaInfo from "@/data/sitemetainfo";
-  import BuyMeACoffee from "./BuyMeACoffee.vue";
   export default {
     name: "TheFooter",
     data() {
@@ -53,7 +52,6 @@
       };
     },
     components: {
-      BuyMeACoffee
     },
     methods: {
       sanitizeHref(href) {


### PR DESCRIPTION
I have removed the following unused components from their respective files:
- **AuthorCard.vue**: Removed `Github` component.
- **TheFooter.vue**: Removed `BuyMeACoffee` component.
- **ProjectCard.vue**: Removed `Folder`, `External`, and `Github` components.

I verified that these components were indeed unused in the templates (some were in commented-out blocks) and that the project still builds successfully with `npm run build`.

---
*PR created automatically by Jules for task [7902344555758309883](https://jules.google.com/task/7902344555758309883) started by @georgebrata*