### PR TITLE
Add JSDoc documentation to missing functions and methods

### DIFF
--- a/components/AuthorCard.vue
+++ b/components/AuthorCard.vue
@@ -129,6 +129,9 @@ export default {
     };
   },
   methods: {
+    /**
+     * Increments the clickIndex up to a maximum of 9, used for cycling through author images.
+     */
     incrementIndex() {
       const MAX = 9;
       if(this.clickIndex < MAX) {

--- a/components/Expertise.vue
+++ b/components/Expertise.vue
@@ -237,6 +237,11 @@
       };
     },
     methods: {
+      /**
+       * Retrieves a skill item from the items list if it matches the name and is marked as visible.
+       * @param {string} skill - The name of the skill to find.
+       * @returns {Object|null} The skill object if found and visible, otherwise null.
+       */
       get(skill) {
         let sIndex = this.items.findIndex(i => i.title.toLowerCase() === skill.toLowerCase());
         if(sIndex > -1 && this.items[sIndex].visible) {

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -81,6 +81,12 @@ export default {
     };
   },
   methods: {
+    /**
+     * Returns a formatted stack item string at a given index.
+     * @param {Object} item - The project item object.
+     * @param {number} index - The index of the stack item to retrieve.
+     * @returns {string} The formatted stack item string or an empty string.
+     */
     getStackItemAtIndex(item, index) {
       return item.stack && item.stack.split(',')[index] ? " • " + item.stack.split(',')[index] : '';
     }

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -56,6 +56,11 @@
       BuyMeACoffee
     },
     methods: {
+      /**
+       * Sanitizes a given URL string to ensure it uses safe protocols or is a local path.
+       * @param {string} href - The URL string to sanitize.
+       * @returns {string} The sanitized URL or '#' if unsafe.
+       */
       sanitizeHref(href) {
         if (!href) return "#";
         const allowedProtocols = ["http:", "https:", "mailto:"];

--- a/components/blogItem.vue
+++ b/components/blogItem.vue
@@ -45,6 +45,11 @@ export default {
     };
   },
   methods: {
+    /**
+     * Converts a date string into a localized long format.
+     * @param {string|Date} date - The date to format.
+     * @returns {string} The formatted date string.
+     */
     formatDate(date) {
       const options = { year: "numeric", month: "long", day: "numeric" };
       return new Date(date).toLocaleDateString("en", options);

--- a/components/blogItemLarge.vue
+++ b/components/blogItemLarge.vue
@@ -63,6 +63,11 @@ export default {
     };
   },
   methods: {
+    /**
+     * Converts a date string into a localized long format.
+     * @param {string|Date} date - The date to format.
+     * @returns {string} The formatted date string.
+     */
     formatDate(date) {
       const options = { year: "numeric", month: "long", day: "numeric" };
       return new Date(date).toLocaleDateString("en", options);

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -79,10 +79,21 @@ export default {
     };
   },
   methods: {
+    /**
+     * Converts a date string into a localized long format.
+     * @param {string|Date} date - The date to format.
+     * @returns {string} The formatted date string.
+     */
     formatDate(date) {
       const options = { year: "numeric", month: "long", day: "numeric" };
       return new Date(date).toLocaleDateString("en", options);
     },
+    /**
+     * Truncates text to a maximum length and appends an ellipsis.
+     * @param {string} text - The text to truncate.
+     * @param {number} [maxLen=25] - The maximum length of the text.
+     * @returns {string} The truncated text.
+     */
     shorten(text, maxLen = 25) {
       return text.length > maxLen ? text.slice(0, maxLen) + "..." : text;
     },

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -55,6 +55,10 @@ export default {
     },
   },
   methods: {
+    /**
+     * Scrolls the categories carousel to a specific index.
+     * @param {number} i - The index of the category to scroll to.
+     */
     scrollToCategory(i) {
       this.$refs.categories.scrollToIndex(i)
     },

--- a/static/js/ga.js
+++ b/static/js/ga.js
@@ -1,4 +1,8 @@
 window.dataLayer = window.dataLayer || [];
+/**
+ * Pushes arguments to the dataLayer for Google Tag Manager.
+ * @param {...any} args - The arguments to be pushed to the dataLayer.
+ */
 function gtag(...args){window.dataLayer.push(args);} 
 gtag('js', new Date());
 


### PR DESCRIPTION
This PR adds JSDoc documentation comments to functions and methods that were missing them across the codebase. This includes the `gtag` function in `static/js/ga.js` as requested, as well as various methods in Vue components and pages. The documentation improves code readability and maintainability by providing clear descriptions of parameters and return values.

---
*PR created automatically by Jules for task [9857353854947409105](https://jules.google.com/task/9857353854947409105) started by @georgebrata*