### PR TITLE
Replace string concatenation with template literals (JS-0246)

### DIFF
--- a/components/AuthorCard.vue
+++ b/components/AuthorCard.vue
@@ -2,7 +2,7 @@
   <div class="md:fixed">
     <div class="md:block flex justify-center items-center">
       <nuxt-img
-        :src="siteMetadata.author_image+'1.png'"
+        :src="`${siteMetadata.author_image}1.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -10,7 +10,7 @@
         v-show="clickIndex === 1"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'2.png'"
+        :src="`${siteMetadata.author_image}2.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -18,7 +18,7 @@
         v-show="clickIndex === 2"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'3.png'"
+        :src="`${siteMetadata.author_image}3.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -26,7 +26,7 @@
         v-show="clickIndex === 3"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'4.png'"
+        :src="`${siteMetadata.author_image}4.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -34,7 +34,7 @@
         v-show="clickIndex === 4"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'5.png'"
+        :src="`${siteMetadata.author_image}5.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -42,7 +42,7 @@
         v-show="clickIndex === 5"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'6.png'"
+        :src="`${siteMetadata.author_image}6.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -50,7 +50,7 @@
         v-show="clickIndex === 6"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'7.png'"
+        :src="`${siteMetadata.author_image}7.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -58,7 +58,7 @@
         v-show="clickIndex === 7"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'8.png'"
+        :src="`${siteMetadata.author_image}8.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full cursor-pointer"
@@ -66,7 +66,7 @@
         v-show="clickIndex === 8"
       />
       <nuxt-img
-        :src="siteMetadata.author_image+'9.png'"
+        :src="`${siteMetadata.author_image}9.png`"
         loading="lazy"
         alt="me"
         class="md:h-60 md:w-60 h-40 w-40 rounded-full"

--- a/components/Expertise.vue
+++ b/components/Expertise.vue
@@ -233,7 +233,7 @@
     data() {
       return {
         items: [],
-        API_URL: process.env.apiUrl + '?path=expertise'
+        API_URL: `${process.env.apiUrl}?path=expertise`
       };
     },
     methods: {

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -85,7 +85,7 @@ export default {
      * @returns {string} The formatted stack item string or an empty string.
      */
     getStackItemAtIndex(item, index) {
-      return item.stack && item.stack.split(',')[index] ? " • " + item.stack.split(',')[index] : '';
+      return item.stack && item.stack.split(',')[index] ? ` • ${item.stack.split(',')[index]}` : '';
     }
   }
 };

--- a/components/TimeLine.vue
+++ b/components/TimeLine.vue
@@ -55,7 +55,7 @@ export default {
   data: () => {
     return {
       items: [],
-      API_URL: process.env.apiUrl.concat('?path=experience')
+      API_URL: `${process.env.apiUrl}?path=experience`
     };
   },
   async fetch() {

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -95,7 +95,7 @@ export default {
      * @returns {string} The truncated text.
      */
     shorten(text, maxLen = 25) {
-      return text.length > maxLen ? text.slice(0, maxLen) + "..." : text;
+      return text.length > maxLen ? `${text.slice(0, maxLen)}...` : text;
     },
   },
   mounted() {

--- a/static/js/clarity.js
+++ b/static/js/clarity.js
@@ -1,5 +1,5 @@
 (function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        t=l.createElement(r);t.async=1;t.src=`https://www.clarity.ms/tag/${i}`;
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "w9hepbyfua");


### PR DESCRIPTION
Replaced string concatenation and `.concat()` with ES6 template literals across several components and scripts to improve readability and comply with modern coding standards (JS-0246). Verified changes with a successful production build and manual code inspection.

---
*PR created automatically by Jules for task [14064094131112358393](https://jules.google.com/task/14064094131112358393) started by @georgebrata*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized several string-building patterns across the site for author images, API requests, and display text.
  * Updated embedded analytics script loading to use the same string format.
  * Kept existing behavior unchanged for image cycling, timeline data loading, project stack display, and blog text truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->