### PR TITLE
Fix short variable names (JS-C1002)

### DIFF
--- a/components/AuthorIntro.vue
+++ b/components/AuthorIntro.vue
@@ -9,8 +9,8 @@
         <HireMeBtn class="block md:hidden">Contact me</HireMeBtn>
       </div>
     </div>
-    <p class="mt-8 mb-4 dark:bg-gray-800 dark:text-blue-200 text-justify" v-for="i in items" :key="i.id">
-      <span v-html="i.description"></span>
+    <p class="mt-8 mb-4 dark:bg-gray-800 dark:text-blue-200 text-justify" v-for="item in items" :key="item.id">
+      <span v-html="item.description"></span>
     </p>
   </div>
 </template>
@@ -24,7 +24,7 @@ export default {
     };
   },
   async fetch() {
-    this.items = await fetch(this.API_URL).then(res => res.json());
+    this.items = await fetch(this.API_URL).then(response => response.json());
   },
 };
 </script>

--- a/components/DownloadCvBtn.vue
+++ b/components/DownloadCvBtn.vue
@@ -12,18 +12,17 @@ export default {
   props: ["file", "name", "fullwidth"],
   methods: {
     downloadFile() {
-      const me = this;
-      fetch(me.file)
-        .then((resp) => resp.blob())
+      fetch(this.file)
+        .then((response) => response.blob())
         .then((blob) => {
           const url = window.URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.style.display = "none";
-          a.href = url;
+          const link = document.createElement("a");
+          link.style.display = "none";
+          link.href = url;
           // the filename you want
-          a.download = me.name || "BrataGeorgeCV.pdf";
-          document.body.appendChild(a);
-          a.click();
+          link.download = this.name || "BrataGeorgeCV.pdf";
+          document.body.appendChild(link);
+          link.click();
           window.URL.revokeObjectURL(url);
         })
         .catch(() => alert("oh no!"));

--- a/components/Expertise.vue
+++ b/components/Expertise.vue
@@ -243,16 +243,16 @@
        * @returns {Object|null} The skill object if found and visible, otherwise null.
        */
       get(skill) {
-        let sIndex = this.items.findIndex(i => i.title.toLowerCase() === skill.toLowerCase());
-        if(sIndex > -1 && this.items[sIndex].visible) {
-          return this.items[sIndex];
+        let skillIndex = this.items.findIndex(item => item.title.toLowerCase() === skill.toLowerCase());
+        if(skillIndex > -1 && this.items[skillIndex].visible) {
+          return this.items[skillIndex];
         } else {
           return null;
         }
       }
     },
     async fetch() {
-      this.items = await fetch(this.API_URL).then(res => res.json());
+      this.items = await fetch(this.API_URL).then(response => response.json());
     },
   };
 </script>

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -10,18 +10,18 @@
           ><span class="sr-only">email</span>
           <img class="w-8 h-8" src="~assets/icon/mail.svg" /></a
         >
-        <a class="text-sm text-gray-500 transition hover:text-gray-600" target="_blank" rel="noopener noreferrer" :href="sanitizeHref(i.href)" v-for="i in items" :key="i.title">
-            <span class="sr-only">{{i.title}}</span>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'cursor'" src="~assets/icon/cursor.svg"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'facebook'" src="~assets/icon/facebook.svg"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'instagram'" src="~assets/icon/instagram.png"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'linkedin'" src="~assets/icon/linkeding.svg"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'twitter'" src="~assets/icon/twitter.png"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'youtube'" src="~assets/icon/youtube.svg"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'github'" src="~assets/icon/github_new.svg"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'codepen'" src="~assets/icon/codepen.png"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'bitbucket'" src="~assets/icon/bitbucket.png"/>
-            <img class="w-8 h-8" v-if="i.title && i.title.toLowerCase() === 'leetcode'" src="~assets/icon/leetcode.png"/>
+        <a class="text-sm text-gray-500 transition hover:text-gray-600" target="_blank" rel="noopener noreferrer" :href="sanitizeHref(item.href)" v-for="item in items" :key="item.title">
+            <span class="sr-only">{{item.title}}</span>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'cursor'" src="~assets/icon/cursor.svg"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'facebook'" src="~assets/icon/facebook.svg"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'instagram'" src="~assets/icon/instagram.png"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'linkedin'" src="~assets/icon/linkeding.svg"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'twitter'" src="~assets/icon/twitter.png"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'youtube'" src="~assets/icon/youtube.svg"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'github'" src="~assets/icon/github_new.svg"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'codepen'" src="~assets/icon/codepen.png"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'bitbucket'" src="~assets/icon/bitbucket.png"/>
+            <img class="w-8 h-8" v-if="item.title && item.title.toLowerCase() === 'leetcode'" src="~assets/icon/leetcode.png"/>
         </a>
       </div>
       <div class="flex mb-2 mt-8 space-x-2 text-sm text-gray-500 dark:text-gray-400">
@@ -80,11 +80,11 @@
       }
     },
     async fetch() {
-      this.items = await fetch(this.API_URL).then(res => res.json());
+      this.items = await fetch(this.API_URL).then(response => response.json());
       let visibleItems = [];
-      this.items.forEach(i => {
-        if(i.visible) {
-          visibleItems.push(i);
+      this.items.forEach(item => {
+        if(item.visible) {
+          visibleItems.push(item);
         }
       })
       this.items = visibleItems;

--- a/components/TimeLine.vue
+++ b/components/TimeLine.vue
@@ -2,46 +2,46 @@
   <div class="opacity-100 mt-10">
 
     <ol class="relative border-l border-gray-200 dark:border-gray-700">
-      <li class="mb-10 ml-6" v-for="i in items" :key="i.title">
+      <li class="mb-10 ml-6" v-for="item in items" :key="item.title">
         <span
           class="flex absolute -left-3 justify-center items-center w-6 h-6 bg-blue-200 rounded-full ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900"
         >
           <img
             class="w-3 h-3 text-blue-600 dark:text-blue-400"
             src="~assets/icon/academy.svg"
-            v-if="i.icon === 'academy'"
+            v-if="item.icon === 'academy'"
           />
           <img
             class="w-3 h-3 text-blue-600 dark:text-blue-400"
             src="~assets/icon/code-1.png"
-            v-if="i.icon === 'code1'"
+            v-if="item.icon === 'code1'"
           />
           <img
             class="w-3 h-3 text-blue-600 dark:text-blue-400"
             src="~assets/icon/code-2.png"
-            v-if="i.icon === 'code2'"
+            v-if="item.icon === 'code2'"
           />
           <img
             class="w-3 h-3 text-blue-600 dark:text-blue-400"
             src="~assets/icon/teach.png"
-            v-if="i.icon === 'teach'"
+            v-if="item.icon === 'teach'"
           />
         </span>
         <h3
           class="flex items-center mb-1 text-lg font-bold text-gray-900 dark:text-white"
         >
-          {{i.title}}
-          <span v-if="i.period && i.period.indexOf('urrent') > -1"
+          {{item.title}}
+          <span v-if="item.period && item.period.indexOf('urrent') > -1"
             class="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-blue-100 dark:text-blue-900 ml-3"
             >Current</span
           >
         </h3>
         <time
           class="block mb-2 text-sm font-normal leading-none text-gray-400 dark:text-gray-500"
-          >{{i.period}}</time
+          >{{item.period}}</time
         >
         <p class="mb-4 text-base font-normal text-gray-500 dark:text-gray-400">
-          {{i.description}}
+          {{item.description}}
         </p>
       </li>
     </ol>
@@ -59,7 +59,7 @@ export default {
     };
   },
   async fetch() {
-    this.items = await fetch(this.API_URL).then(res => res.json());
+    this.items = await fetch(this.API_URL).then(response => response.json());
   },
 };
 </script>

--- a/pages/meet.vue
+++ b/pages/meet.vue
@@ -57,8 +57,8 @@
         };
       },
       async fetch() {
-        let items = await fetch(this.API_URL).then(res => res.json());
-        this.items = items.filter(i => i.visible)
+        let items = await fetch(this.API_URL).then(response => response.json());
+        this.items = items.filter(item => item.visible)
       },
     };
   </script>

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -57,8 +57,8 @@
       };
     },
     async fetch() {
-      let items = await fetch(this.API_URL).then(res => res.json());
-      this.items = items.filter(i => i.visible)
+      let items = await fetch(this.API_URL).then(response => response.json());
+      this.items = items.filter(item => item.visible)
     },
   };
 </script>


### PR DESCRIPTION
This PR addresses the DeepSource issue JS-C1002 by renaming short, uninformative variable names (like 'i', 'a', 'res', 'resp') to more descriptive ones (like 'item', 'link', 'response') across multiple Vue components and pages. This improves code readability and maintainability. Additionally, an unnecessary 'const me = this;' was removed in favor of using 'this' directly within arrow functions in DownloadCvBtn.vue.

---
*PR created automatically by Jules for task [4237668011193704015](https://jules.google.com/task/4237668011193704015) started by @georgebrata*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized how several sections load and render content, improving consistency across the site.
  * Updated social links, timeline, expertise, author intro, portfolio, and meet pages to use more uniform item handling and filtering.
  * Kept download behavior unchanged while making the button logic cleaner and more maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->