### PR TITLE
[codex] Define Vue prop types

### DIFF
--- a/components/DownloadCvBtn.vue
+++ b/components/DownloadCvBtn.vue
@@ -9,7 +9,20 @@
 <script>
 export default {
   name: "DownloadCvBtn",
-  props: ["file", "name", "fullwidth"],
+  props: {
+    file: {
+      type: String,
+      default: "",
+    },
+    name: {
+      type: String,
+      default: "BrataGeorgeCV.pdf",
+    },
+    fullwidth: {
+      type: Boolean,
+      default: false,
+    },
+  },
   methods: {
     downloadFile() {
       const me = this;

--- a/components/HireMeBtn.vue
+++ b/components/HireMeBtn.vue
@@ -10,7 +10,12 @@ import siteMetaInfo from "@/data/sitemetainfo";
 
 export default {
   name: "HireMeBtn",
-  props: ["fullwidth"],
+  props: {
+    fullwidth: {
+      type: Boolean,
+      default: false,
+    },
+  },
     data: () => {
     return {
       siteMetadata: siteMetaInfo,

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -70,7 +70,12 @@
 <script>
 export default {
   name: "ProjectCard",
-  props: ["item"],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
   components: { },
   data() {
     return {

--- a/components/blogItem.vue
+++ b/components/blogItem.vue
@@ -31,7 +31,12 @@
 <script>
 export default {
   name: "BlogItem",
-  props: ["item"],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
   data() {
     return {
       postTitle: this.item?.title,

--- a/components/blogItemLarge.vue
+++ b/components/blogItemLarge.vue
@@ -48,8 +48,12 @@
 <script>
 export default {
   name: "BlogItemLarge",
-  // props: ["title", "description", "date", "slug", "categories", "author", "image", "readingTime"],
-  props: ["item"],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
   data() {
     return {
       postTitle: this.item.title,


### PR DESCRIPTION
## Summary

Converts the affected Vue components from array-style prop declarations to object prop declarations with explicit types.

## Details

- Adds typed string and boolean props to the CV download and hire-me buttons.
- Marks required `item` object props on project and blog card components.
- Removes a stale commented array-style prop declaration.

## Validation

- `rg "props: \\[" components -n`
- `npm run build`

Closes #85
