### PR TITLE
[codex] Avoid this in Nuxt data hooks

### DIFF
--- a/components/AuthorIntro.vue
+++ b/components/AuthorIntro.vue
@@ -15,16 +15,27 @@
   </div>
 </template>
 <script>
+const fetchIntroItems = () => fetch(process.env.apiUrl.concat('?path=intro')).then(res => res.json());
+
 export default {
   name: "AuthorIntro",
   data: () => {
     return {
       items: [],
-      API_URL: process.env.apiUrl.concat('?path=intro')
     };
   },
-  async fetch() {
-    this.items = await fetch(this.API_URL).then(res => res.json());
+  serverPrefetch() {
+    return this.loadItems();
+  },
+  mounted() {
+    if (!this.items.length) {
+      this.loadItems();
+    }
+  },
+  methods: {
+    async loadItems() {
+      this.items = await fetchIntroItems();
+    },
   },
 };
 </script>

--- a/components/Expertise.vue
+++ b/components/Expertise.vue
@@ -204,6 +204,8 @@
   import Pocketbase from "../assets/devicon/pocketbase.svg?inline";
   import Jira from "../assets/devicon/jira.svg?inline";
 
+  const fetchExpertiseItems = () => fetch(`${process.env.apiUrl}?path=expertise`).then(res => res.json());
+
   export default {
     name: "Expertise",
     components: {
@@ -233,10 +235,20 @@
     data() {
       return {
         items: [],
-        API_URL: `${process.env.apiUrl}?path=expertise`
       };
     },
+    serverPrefetch() {
+      return this.loadItems();
+    },
+    mounted() {
+      if (!this.items.length) {
+        this.loadItems();
+      }
+    },
     methods: {
+      async loadItems() {
+        this.items = await fetchExpertiseItems();
+      },
       /**
        * Retrieves a skill item from the items list if it matches the name and is marked as visible.
        * @param {string} skill - The name of the skill to find.
@@ -250,9 +262,6 @@
           return null;
         }
       }
-    },
-    async fetch() {
-      this.items = await fetch(this.API_URL).then(res => res.json());
     },
   };
 </script>

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -62,13 +62,14 @@
 <script>
 import siteMetaInfo from "@/data/sitemetainfo";
 
+const fetchSocialItems = () => fetch(process.env.apiUrl.concat("?path=socials")).then(res => res.json());
+
 export default {
   name: "TheFooter",
   data() {
     return {
       siteMetadata: siteMetaInfo,
       items: [],
-      API_URL: process.env.apiUrl.concat("?path=socials"),
     };
   },
   computed: {
@@ -76,7 +77,19 @@ export default {
       return this.items.filter(i => this.hasPlatformIcon(i.title));
     },
   },
+  serverPrefetch() {
+    return this.loadItems();
+  },
+  mounted() {
+    if (!this.items.length) {
+      this.loadItems();
+    }
+  },
   methods: {
+    async loadItems() {
+      const items = await fetchSocialItems();
+      this.items = items.filter(i => i.visible);
+    },
     /**
      * Sanitizes a given URL string to ensure it uses safe protocols or is a local path.
      * @param {string} href - The URL string to sanitize.
@@ -149,18 +162,6 @@ export default {
       const normalizedTitle = title.toLowerCase();
       return platformNames[normalizedTitle] || title;
     },
-  },
-  async fetch() {
-    this.items = await fetch(this.API_URL).then(res => res.json());
-    const visibleItems = [];
-
-    this.items.forEach(i => {
-      if (i.visible) {
-        visibleItems.push(i);
-      }
-    });
-
-    this.items = visibleItems;
   },
 };
 </script>

--- a/components/TimeLine.vue
+++ b/components/TimeLine.vue
@@ -50,16 +50,27 @@
 </template>
 
 <script>
+const fetchTimelineItems = () => fetch(`${process.env.apiUrl}?path=experience`).then(res => res.json());
+
 export default {
   name: "TimeLine",
   data: () => {
     return {
       items: [],
-      API_URL: `${process.env.apiUrl}?path=experience`
     };
   },
-  async fetch() {
-    this.items = await fetch(this.API_URL).then(res => res.json());
+  serverPrefetch() {
+    return this.loadItems();
+  },
+  mounted() {
+    if (!this.items.length) {
+      this.loadItems();
+    }
+  },
+  methods: {
+    async loadItems() {
+      this.items = await fetchTimelineItems();
+    },
   },
 };
 </script>

--- a/pages/hobbies.vue
+++ b/pages/hobbies.vue
@@ -86,13 +86,17 @@
 
 <script>
     // import projectsData from "../data/projects";
+    const fetchHobbyItems = () => fetch(process.env.apiUrl.concat('?path=hobbies')).then(res => res.json());
+
     export default {
         name: "Hobbies",
+        async asyncData() {
+            const items = await fetchHobbyItems();
+            return { items };
+        },
         data() {
             return {
-                items: [],
                 activeIndex: Math.floor(Math.random() * 10) % 5,
-                API_URL: process.env.apiUrl.concat('?path=hobbies')
             };
         },
         head() {
@@ -117,9 +121,6 @@
                     href: "/favicon.ico"
                 }],
             };
-        },
-        async fetch() {
-            this.items = await fetch(this.API_URL).then(res => res.json());
         },
     };
 </script>

--- a/pages/meet.vue
+++ b/pages/meet.vue
@@ -25,12 +25,20 @@
   
   <script>
     // import projectsData from "../data/projects";
+    const fetchVisibleProjectItems = async () => {
+      const items = await fetch(process.env.apiUrl.concat('?path=projects')).then(res => res.json());
+      return items.filter(i => i.visible);
+    };
+
     export default {
       name: "Meet",
+      async asyncData() {
+        const items = await fetchVisibleProjectItems();
+        return { items };
+      },
       data() {
         return {
           items: [],
-          API_URL: process.env.apiUrl.concat('?path=projects')
         };
       },
       head() {
@@ -55,10 +63,6 @@
             href: "/favicon.ico"
           }],
         };
-      },
-      async fetch() {
-        const items = await fetch(this.API_URL).then(res => res.json());
-        this.items = items.filter(i => i.visible)
       },
     };
   </script>

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -25,12 +25,20 @@
 
 <script>
   // import projectsData from "../data/projects";
+  const fetchVisibleProjectItems = async () => {
+    const items = await fetch(process.env.apiUrl.concat('?path=projects')).then(res => res.json());
+    return items.filter(i => i.visible);
+  };
+
   export default {
     name: "Portfolio",
+    async asyncData() {
+      const items = await fetchVisibleProjectItems();
+      return { items };
+    },
     data() {
       return {
         items: [],
-        API_URL: process.env.apiUrl.concat('?path=projects')
       };
     },
     head() {
@@ -55,10 +63,6 @@
           href: "/favicon.ico"
         }],
       };
-    },
-    async fetch() {
-      const items = await fetch(this.API_URL).then(res => res.json());
-      this.items = items.filter(i => i.visible)
     },
   };
 </script>


### PR DESCRIPTION
## Summary

Refactors the affected Nuxt data-loading hooks so they no longer use `this` inside Nuxt `fetch` hooks.

## Details

- Moves page-level loading in `hobbies`, `meet`, and `portfolio` to `asyncData`.
- Replaces component Nuxt `fetch` hooks with shared loaders plus `serverPrefetch` and `mounted` fallback behavior.
- Keeps filtering behavior for visible project and social items.

## Validation

- `rg "async\\s+fetch\\s*\\(" components pages -n`
- `npm run build`
- `npm run generate` exited successfully and generated routes. It still emits a pre-existing Nuxt Image/IPX message for `/static/author`, which is unrelated to these data-loading changes.

Closes #84
